### PR TITLE
Add setup and teardown hooks to Courgette

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,23 +205,7 @@ You can add global setup and tear-down code to your Courgette test runner using 
 
 ```java
 @RunWith(Courgette.class)
-@CourgetteOptions(
-        threads = 10,
-        runLevel = CourgetteRunLevel.SCENARIO,
-        rerunFailedScenarios = true,
-        showTestOutput = true,
-        reportTargetDir = "build",
-        cucumberOptions = @CucumberOptions(
-                features = "src/test/resources/features",
-                glue = "steps",
-                tags = {"@regression", "not @wip"},
-                plugin = {
-                        "pretty",
-                        "json:build/cucumber-report/cucumber.json",
-                        "html:build/cucumber-report/cucumber.html",
-                        "junit:build/cucumber-report/cucumber.xml"},
-                strict = true
-        ))
+@CourgetteOptions(/* Your Courgette options here... */)
 public class RegressionTestSuite {
     @CourgetteBeforeAll
     public static void setUp() {

--- a/README.md
+++ b/README.md
@@ -199,6 +199,45 @@ gradle regressionSuite -Dcourgette.vmoptions="-Xms256m -Xmx512m"
 
 ````
 
+## Callbacks
+
+You can add global setup and tear-down code to your Courgette test runner using the `@CourgetteBeforeAll` and `@CourgetteAfterAll` annotations. For example:
+
+```java
+@RunWith(Courgette.class)
+@CourgetteOptions(
+        threads = 10,
+        runLevel = CourgetteRunLevel.SCENARIO,
+        rerunFailedScenarios = true,
+        showTestOutput = true,
+        reportTargetDir = "build",
+        cucumberOptions = @CucumberOptions(
+                features = "src/test/resources/features",
+                glue = "steps",
+                tags = {"@regression", "not @wip"},
+                plugin = {
+                        "pretty",
+                        "json:build/cucumber-report/cucumber.json",
+                        "html:build/cucumber-report/cucumber.html",
+                        "junit:build/cucumber-report/cucumber.xml"},
+                strict = true
+        ))
+public class RegressionTestSuite {
+    @CourgetteBeforeAll
+    public static void setUp() {
+        System.out.println("I will run before any tests execute");
+    }
+    
+    @CourgetteAfterAll
+    public static void tearDown() {
+        System.out.println("I will run after all of the tests execute");
+    }
+}
+```
+
+You can add any number of annotated methods to your test suite class. 
+If you need your callbacks to run in a specific order, pass `order` to the annotation: `@CourgetteBeforeAll(order = 2)`.
+
 ## Limitations and Known Issues
 
 * JUnit test notifier is not updated when running features in the IDE during parallel test execution.

--- a/src/main/java/courgette/api/CourgetteAfterAll.java
+++ b/src/main/java/courgette/api/CourgetteAfterAll.java
@@ -1,0 +1,13 @@
+package courgette.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface CourgetteAfterAll {
+    int order() default 0;
+}
+

--- a/src/main/java/courgette/api/CourgetteBeforeAll.java
+++ b/src/main/java/courgette/api/CourgetteBeforeAll.java
@@ -1,0 +1,12 @@
+package courgette.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface CourgetteBeforeAll {
+    int order() default 0;
+}

--- a/src/main/java/courgette/runtime/CourgetteCallbacks.java
+++ b/src/main/java/courgette/runtime/CourgetteCallbacks.java
@@ -1,0 +1,49 @@
+package courgette.runtime;
+
+import courgette.api.CourgetteAfterAll;
+import courgette.api.CourgetteBeforeAll;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CourgetteCallbacks {
+    private final Class<?> clazz;
+
+    public CourgetteCallbacks(Class<?> clazz) {
+        this.clazz = clazz;
+    }
+
+    public void beforeAll() {
+        getCallbacksForAnnotation(CourgetteBeforeAll.class).stream()
+                .sorted(Comparator.comparingInt(method -> method.getAnnotation(CourgetteBeforeAll.class).order()))
+                .forEachOrdered(method -> invokeCallback(method));
+    }
+
+    public void afterAll() {
+        getCallbacksForAnnotation(CourgetteAfterAll.class).stream()
+                .sorted(Comparator.comparingInt(method -> method.getAnnotation(CourgetteAfterAll.class).order()))
+                .forEachOrdered(method -> invokeCallback(method));
+    }
+
+    private List<Method> getCallbacksForAnnotation(Class<? extends Annotation> annotation) {
+        return Arrays.stream(clazz.getMethods())
+                .filter(method -> Modifier.isStatic(method.getModifiers())
+                        && method.isAnnotationPresent(annotation)
+                        && method.getParameterCount() == 0)
+                .collect(Collectors.toList());
+    }
+
+    private void invokeCallback(Method callback, Object... args) {
+        try {
+            callback.invoke(null, args);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new CourgetteException(e);
+        }
+    }
+}


### PR DESCRIPTION
I'm open to suggestions on the design of the API. I named the annotations such that they would not collide with any existing test framework annotation names, and could be extended in the future if needed (such as `@CourgetteBeforeEach` etc.)